### PR TITLE
fix/rounded product prices to nearest integer

### DIFF
--- a/src/app/Features/Product/ProductSlice.js
+++ b/src/app/Features/Product/ProductSlice.js
@@ -8,12 +8,17 @@ export const getAllProducts = createAsyncThunk(
   async () => {
     try {
       let { data } = await axios.get("https://fakestoreapi.com/products");
-      return data;
+      const roundedData = data.map((product) => ({
+        ...product,
+        price: Math.round(product.price),
+      }));
+      return roundedData;
     } catch (error) {
       return axiosErrorHandler(error);
     }
   }
 );
+
 const productSlice = createSlice({
   name: "products",
   initialState: { isLoading: false, products: [], error: null },


### PR DESCRIPTION
In product slice, used math.round to round of the price in the thunk as soon as they were fetched before returning