### PR TITLE
fix: improve cart totals visisbililty in dark mode

### DIFF
--- a/src/app/Coponents/Cart/CartItemCard.js
+++ b/src/app/Coponents/Cart/CartItemCard.js
@@ -67,7 +67,7 @@ function CartItemCard({ item }) {
                 <FaPlus />
               </button>
             </div>
-            <div className="w-100 text-center">
+            <div className="w-100 text-center cart-total">
               <span className="fs-5">
                 ₹
                 {product.price

--- a/src/app/Coponents/Header/TopNavbar.js
+++ b/src/app/Coponents/Header/TopNavbar.js
@@ -55,9 +55,27 @@ function TopNavbar({ darkMode, toggleMode }) {
             </NavLink>
           </Nav>
         </Navbar.Collapse>
-        <button className="mode" onClick={toggleMode} style={{ marginLeft: '1rem' }}>
-          {darkMode ? '☀️' : '🌙'}
-        </button>
+        <button
+  className="mode"
+  onClick={toggleMode}
+  style={{
+    marginLeft: '1rem',
+    width: '35px',
+    height: '35px',
+    borderRadius: '50%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '1px solid #ccc',
+    background: darkMode ? '#222' : '#fff',
+    color: darkMode ? '#fff' : '#222',
+    cursor: 'pointer'
+  }}
+>
+  <span style={{ fontSize: '1.4rem' }}>
+    {darkMode ? '☀️' : '🌙'}
+  </span>
+</button>
       </Container>
     </Navbar>
   );

--- a/src/app/Pages/Cart.js
+++ b/src/app/Pages/Cart.js
@@ -64,15 +64,15 @@ function Cart() {
               <Card.Body>
                 <div className="d-flex justify-content-around">
                   <div className="w-100 align-middle">
-                    <h5 className="align-middle d-inline">
+                    <h5 className="align-middle d-inline cart-total">
                       Subtotal: ₹{subTotal}
                     </h5>
                   </div>
                   <div className="w-100 ">
-                    <h5 className="align-middle d-inline">Tax(2%): ₹{tax}</h5>
+                    <h5 className="align-middle d-inline cart-total">Tax(2%): ₹{tax}</h5>
                   </div>
                   <div className="w-100 align-middle">
-                    <h5 className="align-middle d-inline">
+                    <h5 className="align-middle d-inline cart-total">
                       Total Price: ₹{Math.round(totalAmmount)}
                     </h5>
                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,6 @@ body {
   background: #222;
   color: #fff;
 }
+html.dark .cart-total {
+  color: #151414 !important;
+}


### PR DESCRIPTION
## Fix: Improve Cart Totals Visibility in Dark Mode (#18)

### What does this PR do?
- Fixes the visibility of subtotal, tax, and total price on the cart page when dark mode is enabled.
- Ensures cart totals are readable in both light and dark themes.
- (Optional) Enhances the theme toggle button UI for better appearance and usability.

### Related Issue
Closes #18

### Screenshots (Before & After)
<!-- If possible, add screenshots showing the cart totals in both light and dark mode, before and after your fix. -->
<img width="1919" height="971" alt="Screenshot 2025-07-11 190631" src="https://github.com/user-attachments/assets/5cfa1ce7-eba1-4701-b7b1-bb05114ab9a7" />



### Additional Notes
- The fix uses a custom `.cart-total` class and CSS targeting the `.dark` class on the `<html>` element.
- The theme toggle button is now styled as a circular button with a larger emoji for better UX.